### PR TITLE
Default to post date when there is no article date

### DIFF
--- a/imports/startup/server/index.coffee
+++ b/imports/startup/server/index.coffee
@@ -54,13 +54,15 @@ Meteor.methods
                 (group_concat(DISTINCT ?rawText; separator = "::") AS ?articleRawMenions)
               WHERE {
                   ?phrase anno:category "diseases"
-                      ; anno:source_doc ?currentArticle
-                      ; anno:start ?start
-                      ; anno:selected-text ?rawText
-                      ; ^dc:relation ?resolvedTerm
-                      .
+                  ; anno:source_doc ?currentArticle
+                  ; anno:start ?start
+                  ; anno:selected-text ?rawText
+                  ; ^dc:relation ?resolvedTerm
+                  .
                   ?resolvedTerm rdfs:label ?termLabel .
-                  ?currentArticle pro:date ?currentDate .
+                  ?currentArticle pro:post/pro:date ?p_date .
+                  OPTIONAL { ?currentArticle  pro:date  ?a_date }
+                  BIND(coalesce(?a_date, ?p_date) AS ?currentDate)
               }
               GROUP BY ?resolvedTerm ?termLabel ?currentDate ?currentArticle
               # Sort by date, then document, then offset within the document.
@@ -70,9 +72,11 @@ Meteor.methods
           # Select the previous usages of the most recently mentioned terms
           OPTIONAL {
             ?prev_mention anno:source_doc ?prevArticle
-                ; ^dc:relation ?resolvedTerm
-                .
-            ?prevArticle pro:date ?prevDate .
+            ; ^dc:relation ?resolvedTerm
+            .
+            ?prevArticle pro:post/pro:date ?p_date .
+            OPTIONAL { ?prevArticle  pro:date  ?a_date }
+            BIND(coalesce(?a_date, ?p_date) AS ?prevDate)
             FILTER(?currentDate >= ?prevDate && ?currentArticle != ?prevArticle)
           }
       }
@@ -84,7 +88,7 @@ Meteor.methods
 
   'getHistoricalData': (termLabel) ->
     query = prefixes + """
-      SELECT (max(?dateTime) as ?mdt)
+      SELECT (max(?date) as ?mdt)
       WHERE {
         ?phrase anno:category "diseases"
         ; anno:source_doc ?currentArticle
@@ -92,7 +96,9 @@ Meteor.methods
         ; ^dc:relation ?resolvedTerm
         .
         ?resolvedTerm rdfs:label ?termLabel .
-        ?currentArticle pro:date ?dateTime
+        ?currentArticle pro:post/pro:date ?p_date .
+        OPTIONAL { ?currentArticle  pro:date  ?a_date }
+        BIND(coalesce(?a_date, ?p_date) AS ?date)
         filter(?termLabel = "#{termLabel}")
       }
       """
@@ -110,7 +116,9 @@ Meteor.methods
         ; ^dc:relation ?resolvedTerm
         .
         ?resolvedTerm rdfs:label ?termLabel .
-        ?currentArticle pro:date ?dateTime
+        ?currentArticle pro:post/pro:date ?p_date .
+        OPTIONAL { ?currentArticle  pro:date  ?a_date }
+        BIND(coalesce(?a_date, ?p_date) AS ?dateTime)
         FILTER(?termLabel = "#{termLabel}")
         FILTER (?dateTime > "#{baseYear}-01-01T00:00:00+00:01"^^xsd:dateTime)
       }
@@ -139,25 +147,30 @@ Meteor.methods
 
   'getRecentMentions': (agent) ->
     query = prefixes + """
-      SELECT DISTINCT ?phrase_text ?p_start ?t_start ?t_end ?source ?date
+      SELECT DISTINCT
+        ?phrase_text ?p_start
+        ?t_start ?t_end
+        ?source ?date
       WHERE {
           ?phrase anno:selected-text ?phrase_text
-              ; anno:start ?p_start
-              ; anno:end ?p_end
-              ; dep:ROOT ?noop
-              ; anno:contains ?target
-              .
+          ; anno:start ?p_start
+          ; anno:end ?p_end
+          ; dep:ROOT ?noop
+          ; anno:contains ?target
+          .
           {
               ?target anno:label "#{agent}"
           } UNION {
               ?resolvedTarget dc:relation ?target
-                  ; rdfs:label "#{agent}"
+              ; rdfs:label "#{agent}"
           } .
           ?target anno:start ?t_start
-              ; anno:end ?t_end
-              ; anno:source_doc ?source
-              .
-          ?source pro:date ?date .
+          ; anno:end ?t_end
+          ; anno:source_doc ?source
+          .
+          ?source pro:post/pro:date ?p_date .
+          OPTIONAL { ?source  pro:date  ?a_date }
+          BIND(coalesce(?a_date, ?p_date) AS ?date)
       }
       ORDER BY DESC(?date) DESC(?source) ASC(?t_start)
       LIMIT 10


### PR DESCRIPTION
Currently some articles are omitted because they have no date. This PR alters the queries to use the post date (which is always defined) when the article doesn't have a date.
