### PR TITLE
Fix KWIC view formatting for all screen sizes.

### DIFF
--- a/imports/ui/lists/recentMentions.coffee
+++ b/imports/ui/lists/recentMentions.coffee
@@ -28,9 +28,9 @@ Template.recentMentions.helpers
   mentionsForSource: (sourceId) ->
     Template.instance().mentions.find(sourceId: sourceId)
   kwic: ->
-    new Spacebars.SafeString """
-      <span>...#{@phrase_text.slice(Math.max(0, @t_start - 40 - @p_start), @t_start - @p_start)}
-        <strong>#{@phrase_text.slice(@t_start - @p_start, @t_end - @p_start)}</strong>
+    new Spacebars.SafeString """<span>...#{@phrase_text.slice(Math.max(0, @t_start - 40 - @p_start), @t_start - @p_start)}</span>
+      <span>
+          <strong>#{@phrase_text.slice(@t_start - @p_start, @t_end - @p_start)}</strong>
         #{@phrase_text.slice(@t_end - @p_start, @t_start + 40 - @p_start)}...
       </span>
       """

--- a/imports/ui/lists/recentMentions.coffee
+++ b/imports/ui/lists/recentMentions.coffee
@@ -29,8 +29,7 @@ Template.recentMentions.helpers
     Template.instance().mentions.find(sourceId: sourceId)
   kwic: ->
     new Spacebars.SafeString """
-      <span>...#{@phrase_text.slice(Math.max(0, @t_start - 40 - @p_start), @t_start - @p_start)}</span>
-      <span>
+      <span>...#{@phrase_text.slice(Math.max(0, @t_start - 40 - @p_start), @t_start - @p_start)}
         <strong>#{@phrase_text.slice(@t_start - @p_start, @t_end - @p_start)}</strong>
         #{@phrase_text.slice(@t_end - @p_start, @t_start + 40 - @p_start)}...
       </span>

--- a/imports/ui/stylesheets/recent_mentions.import.styl
+++ b/imports/ui/stylesheets/recent_mentions.import.styl
@@ -1,12 +1,15 @@
 #recentMentionsTable
   .kwic
-    text-align center
+    white-space nowrap
     margin auto
     :nth-child(1)
+      text-align right
       margin-right .5em
     :nth-child(1)
     :nth-child(2)
       display inline-block
+      width 23em
+      white-space nowrap
       strong
         display inline
         margin-right 0px

--- a/imports/ui/stylesheets/recent_mentions.import.styl
+++ b/imports/ui/stylesheets/recent_mentions.import.styl
@@ -1,14 +1,12 @@
 #recentMentionsTable
   .kwic
+    text-align center
     margin auto
     :nth-child(1)
-      text-align right
       margin-right .5em
     :nth-child(1)
     :nth-child(2)
       display inline-block
-      width 23em
-      white-space nowrap
       strong
         display inline
         margin-right 0px


### PR DESCRIPTION
- Combined spans into one and center aligned the text.  With two spans, when the screen was resized the second span was treated as a second block and the entire span was moved to the next line..
- Turned word-wrap back on so small screen sizes would display all text.
