### PR TITLE
make the Chart.js widget to always account for 0 inside the bar chart

### DIFF
--- a/imports/ui/components/timeline.coffee
+++ b/imports/ui/components/timeline.coffee
@@ -150,6 +150,7 @@ Template.timeline.onRendered ->
               ticks:
                 min: 0
                 display: false
+                beginAtZero: true
               gridLines:
                 lineWidth: 0,
                 color: "rgba(255,255,255,0)"


### PR DESCRIPTION
seems like `min: 0` has fixed the issue with disappearing bars already, but it might be a good idea to add this option as well just to be sure
