### PR TITLE
Remove redundant text in recently mentioned table

### DIFF
--- a/imports/ui/lists/frequentAgents.jade
+++ b/imports/ui/lists/frequentAgents.jade
@@ -11,6 +11,6 @@ template(name="frequentAgents")
             td.frequentlyMentionedInfectiousAgentsTableRow(data-agentname=word)
               span.fmia-word
                 a(href="/detail/#{word}")= word
-            td appears in {{pluralize 'article' count}}
+            td= count
     unless ready
       +loader classes='inline'


### PR DESCRIPTION
In a previous PR I forgot to remove the text in each cell that became redundant after adding the column header.
