### PR TITLE
Add seasonal trend indicator

### DIFF
--- a/imports/startup/server/index.coffee
+++ b/imports/startup/server/index.coffee
@@ -486,23 +486,35 @@ api.addRoute 'trendingAgents/:range',
     stopDateStr = trendingMoment.format("YYYY-MM-DD") + "T00:00:00+00:01"
     dateStr = date.format("YYYY-MM-DD") + "T00:00:00+00:01"
     dateStr2 = date2.format("YYYY-MM-DD") + "T00:00:00+00:01"
+    seasonDays = 3 * 5 * 30
+    seasonMonths = [-1, 0, 1].map (offset)->
+      ((trendingMoment.month() + offset) % 12) + 1
     query = prefixes + """
       SELECT
         ?resolvedTerm ?word
-        ?count ?count2
+        ?rate ?rate2
         ?result
+        (count(DISTINCT ?seasonal_post) / xsd:float(#{seasonDays}) as ?seasonal_rate)
       WHERE {
-        # There is an extra level of nesting here bc virtuoso doesn't allow
-        # variables bound in select statements to be used for ordering.
+        ?seasonal_mention anno:source_doc ?seasonal_source
+        ; ^dc:relation ?resolvedTerm
+        ; anno:category "diseases"
+        .
+        ?seasonal_source pro:post ?seasonal_post .
+        ?seasonal_post pro:date ?seasonal_date
+        FILTER (month(?seasonal_date) IN (#{seasonMonths}))
+        # Use previous 5 years to establish seasonal baseline rate
+        FILTER (?seasonal_date > "#{trendingMoment.year() - 6}"^^xsd:dateTime)
+        FILTER (?seasonal_date <= "#{trendingMoment.year() - 1}"^^xsd:dateTime)
         {
           SELECT ?resolvedTerm
             (sample(?termLabel) as ?word)
             (count(DISTINCT ?post) as ?count)
             (sample(?c2) as ?count2)
           WHERE {
-            ?phrase anno:category "diseases"
+            ?phrase anno:source_doc ?source
             ; ^dc:relation ?resolvedTerm
-            ; anno:source_doc ?source
+            ; anno:category "diseases"
             .
             ?source pro:post ?post .
             ?post pro:date ?dateTime
@@ -514,10 +526,11 @@ api.addRoute 'trendingAgents/:range',
             FILTER (?dateTime > "#{escape(dateStr)}"^^xsd:dateTime)
             FILTER (?dateTime <= "#{escape(stopDateStr)}"^^xsd:dateTime)
             {
-              SELECT (count(DISTINCT ?post2) as ?c2) ?resolvedTerm ?termLabel2
+              SELECT (count(DISTINCT ?post2) as ?c2) ?resolvedTerm
               WHERE {
                 ?prev_mention anno:source_doc ?source2
                 ; ^dc:relation ?resolvedTerm
+                ; anno:category "diseases"
                 .
                 ?source2 pro:post ?post2 .
                 ?post2 pro:date ?dateTime2
@@ -525,11 +538,10 @@ api.addRoute 'trendingAgents/:range',
                   ; pro:feed_id "#{escape(promedFeedId)}"
                 """ else ""}
                 .
-          		  ?resolvedTerm rdfs:label ?termLabel2
                 FILTER (?dateTime2 > "#{escape(dateStr2)}"^^xsd:dateTime)
                 FILTER (?dateTime2 <= "#{escape(stopDateStr)}"^^xsd:dateTime)
-               }
-              GROUP BY ?resolvedTerm ?termLabel2
+              }
+              GROUP BY ?resolvedTerm
             }
           }
           GROUP BY ?resolvedTerm
@@ -539,6 +551,7 @@ api.addRoute 'trendingAgents/:range',
         BIND(?rate - ?rate2 AS ?result)
         FILTER(?result > 0)
       }
+      GROUP BY ?resolvedTerm ?word ?rate ?rate2 ?result
       ORDER BY DESC(?result)
       LIMIT 50
       """

--- a/imports/startup/server/index.coffee
+++ b/imports/startup/server/index.coffee
@@ -486,7 +486,9 @@ api.addRoute 'trendingAgents/:range',
     stopDateStr = trendingMoment.format("YYYY-MM-DD") + "T00:00:00+00:01"
     dateStr = date.format("YYYY-MM-DD") + "T00:00:00+00:01"
     dateStr2 = date2.format("YYYY-MM-DD") + "T00:00:00+00:01"
+    # The number of days in the last 5 seasons used to establish seasonal rate.
     seasonDays = 3 * 5 * 30
+    # Month numbers for months in the season
     seasonMonths = [-1, 0, 1].map (offset)->
       ((trendingMoment.month() + offset) % 12) + 1
     query = prefixes + """

--- a/imports/ui/lists/trendingAgents.coffee
+++ b/imports/ui/lists/trendingAgents.coffee
@@ -26,13 +26,15 @@ Template.trendingAgents.onCreated ->
       maxScore = _.max(filteredResults, (binding)->binding.result).result
       for binding in filteredResults
         binding.bars = _.range(Math.round(3 * binding.result / maxScore))
+        # yearly trends cannot be seasonal
+        binding.seasonal = @trendingRange.get() != "year" and (binding.seasonal_rate / binding.rate) > 0.75
         @trendingAgents.insert(binding)
 
 Template.trendingAgents.onRendered ->
-    @$('.date-picker').data('DateTimePicker')?.destroy()
-    @$('.date-picker').datetimepicker(
-      format: 'MM/DD/YYYY'
-    )
+  @$('.date-picker').data('DateTimePicker')?.destroy()
+  @$('.date-picker').datetimepicker(
+    format: 'MM/DD/YYYY'
+  )
 
 Template.trendingAgents.helpers
   trendingAgents: ->
@@ -47,5 +49,5 @@ Template.trendingAgents.events
     d = $(event.target).data('DateTimePicker')?.date().toDate()
     if d then instance.trendingDate.set d
 
-Template.powerBars.onRendered ->
+Template.trendingAgent.onRendered ->
   @$('[data-toggle="tooltip"]').tooltip()

--- a/imports/ui/lists/trendingAgents.jade
+++ b/imports/ui/lists/trendingAgents.jade
@@ -20,10 +20,8 @@ template(name="trendingAgents")
 
     ul.trending-agents.list--sub-group.list-unstyled
       each trendingAgents
-        li(data-agentname=word)
-          a.fmia-word(href="/detail/#{word}")= word
-          .relative-strength
-            +powerBars
+        li
+          +trendingAgent
       else
         if ready
           p.no-priors.centered.subtle No Trending Infectious Agents in the last
@@ -31,7 +29,19 @@ template(name="trendingAgents")
         else
           +loader classes='inline'
 
-template(name="powerBars")
-  .power-bars(data-toggle="tooltip" data-placement="left" title="The number of bars indicates the relative strength of the trend.")
-    each bars
-      .power-bar
+template(name="trendingAgent")
+  a.fmia-word(href="/detail/#{word}")= word
+  if seasonal
+    a.fa.fa-sun-o.seasonal(
+      data-toggle="tooltip"
+      data-placement="right"
+      title="This may be a seasonal trend."
+    )
+  .relative-strength
+    .power-bars(
+      data-toggle="tooltip"
+      data-placement="left"
+      title="The number of bars indicates the relative strength of the trend."
+    )
+      each bars
+        .power-bar

--- a/imports/ui/lists/trendingAgents.jade
+++ b/imports/ui/lists/trendingAgents.jade
@@ -32,7 +32,7 @@ template(name="trendingAgents")
 template(name="trendingAgent")
   a.fmia-word(href="/detail/#{word}")= word
   if seasonal
-    a.fa.fa-sun-o.seasonal(
+    span.fa.fa-sun-o.seasonal(
       data-toggle="tooltip"
       data-placement="right"
       title="This may be a seasonal trend."

--- a/imports/ui/stylesheets/main.import.styl
+++ b/imports/ui/stylesheets/main.import.styl
@@ -8,8 +8,8 @@
   cursor hand
   color $secondary
 
-a.seasonal
-  color orange
+.seasonal
+  color $primary
   margin-left 0.5em
   line-height 1.3em
 

--- a/imports/ui/stylesheets/main.import.styl
+++ b/imports/ui/stylesheets/main.import.styl
@@ -8,6 +8,11 @@
   cursor hand
   color $secondary
 
+a.seasonal
+  color orange
+  margin-left 0.5em
+  line-height 1.3em
+
 #trendingRange
 #timelineRange
   width 100px


### PR DESCRIPTION
This adds a "seasonal" indicator to monthly and weekly trending agents that have a rate of mentions near the average rate (established over the previous 5 years) for the current season.
