### PR TITLE
Remove open class on mouseout

### DIFF
--- a/imports/ui/layouts/header.coffee
+++ b/imports/ui/layouts/header.coffee
@@ -12,7 +12,7 @@ Template.header.events
     instance.$(event.currentTarget).addClass('open')
 
   'mouseout .dropdown': (event, instance) ->
-    instance.$(event.target).blur()
+    instance.$(event.currentTarget).removeClass('open').blur()
 
   'click .region-selector li, touchend .region-selector li': (event, instance) ->
     instance.$('.dropdown').removeClass('open').blur()


### PR DESCRIPTION
Fixes up a small issue introduced in a previous PR where the _Feeds_ dropdown lingers after mouseout.

PT Bug: https://www.pivotaltracker.com/story/show/132616375
