### PR TITLE
Prior mention links scroll the recently mentioned diseases to the date of the mention

### DIFF
--- a/imports/startup/server/index.coffee
+++ b/imports/startup/server/index.coffee
@@ -285,18 +285,16 @@ api.addRoute 'recentAgents',
     start = moment(@queryParams.start or moment().subtract(2, 'weeks'))
     end = moment(@queryParams.end or moment())
     # Round dates up to the day end so that they are cached
-    start.set(
+    start.set
       hour: 23
       minute: 59
       second: 59
       millisecond: 0
-    )
-    end.set(
+    end.set
       hour: 23
       minute: 59
       second: 59
       millisecond: 0
-    )
     query = prefixes + """
       SELECT
           # For each of the most recently mentioned terms find the most recent

--- a/imports/ui/helpers/time.coffee
+++ b/imports/ui/helpers/time.coffee
@@ -7,6 +7,9 @@ tick = ->
 
 setInterval tick, tickInterval
 
+Template.registerHelper 'format', (date, formatString) ->
+  moment(date).format(formatString)
+
 Template.registerHelper 'age', (date) ->
   Session.get('now') # triggers the reactivity every second
   moment(date).local().fromNow()

--- a/imports/ui/lists/recentAgents.coffee
+++ b/imports/ui/lists/recentAgents.coffee
@@ -8,7 +8,6 @@ Template.recentAgents.onCreated ->
   @pageEndDate = new ReactiveVar(moment())
   @loadingMorePosts = new ReactiveVar(false)
   @weeksWithNoPosts = new ReactiveVar(0)
-  #Router.go("/?q=10")
   @loadMorePosts = =>
     if @loadingMorePosts.get() then return
     @loadingMorePosts.set(true)

--- a/imports/ui/lists/recentAgents.coffee
+++ b/imports/ui/lists/recentAgents.coffee
@@ -39,13 +39,11 @@ Template.recentAgents.onCreated ->
             collapsed: false
         row.postId = postId
         if row.priorPostDate
-          row.priorPostDate = moment.utc(row.priorPostDate).toDate()
           postDate = moment.utc(row.postDate)
+          row.postDate = postDate.toDate()
+          row.priorPostDate = moment.utc(row.priorPostDate).toDate()
           row.days = postDate.diff(row.priorPostDate, 'days')
           row.months = postDate.diff(row.priorPostDate, 'months')
-          #show days or months since last mention
-          if row.days > 30
-            row.dm = true
         @recentAgents.insert(row)
       # ...
       @posts.find().forEach (post) =>

--- a/imports/ui/lists/recentAgents.coffee
+++ b/imports/ui/lists/recentAgents.coffee
@@ -1,33 +1,33 @@
 require './recentAgents.jade'
 
-pp = 75
-
 Template.recentAgents.onCreated ->
   @recentAgents = new Meteor.Collection(null)
   @posts = new Meteor.Collection(null)
-  @currentPageNumber = new ReactiveVar(0)
-  @ready = new ReactiveVar(false)
-  @theEnd = new ReactiveVar(false)
-  order = 0
-
+  @startDate = new ReactiveVar(moment())
+  @endDate = new ReactiveVar(moment())
+  @pageEndDate = new ReactiveVar(moment())
+  @loadingMorePosts = new ReactiveVar(false)
+  @weeksWithNoPosts = new ReactiveVar(0)
+  #Router.go("/?q=10")
   @loadMorePosts = =>
-    if not @ready.get() then return
-    pageNum = @currentPageNumber.get()
-    @currentPageNumber.set(pageNum + 1)
-    # @recentAgents.find({}, reactive: false).map((d) => @recentAgents.remove(d))
-    @ready.set(false)
+    if @loadingMorePosts.get() then return
+    @loadingMorePosts.set(true)
+    @pageEndDate.set @startDate.get()
+    @startDate.set moment(@startDate.get()).subtract(2, 'weeks')
     HTTP.get '/api/recentAgents', {
       params:
         promedFeedId: Session.get('promedFeedId')  or null
-        page: pageNum
-        pp: pp
+        end: @pageEndDate.get().toISOString()
+        start: @startDate.get().toISOString()
     }, (err, res) =>
-      @ready.set(true)
+      @loadingMorePosts.set(false)
       if err
         toastr.error(err.message)
         return
       unless res.data.results.length
-        @theEnd.set(true)
+        @weeksWithNoPosts.set(@weeksWithNoPosts.get() + 2)
+        if @weeksWithNoPosts.get() <= 2
+          @loadMorePosts()
         return
       for row in res.data.results
         postId = @posts.findOne(uri: row.post)?._id
@@ -37,7 +37,6 @@ Template.recentAgents.onCreated ->
             postSubject: row.postSubject
             postDate: moment.utc(row.postDate)
             collapsed: false
-            order: order++
         row.postId = postId
         if row.priorPostDate
           row.priorPostDate = moment.utc(row.priorPostDate).toDate()
@@ -94,21 +93,41 @@ Template.recentAgents.onRendered ->
 
   infiniteScroll(options)
 
-  @autorun =>
-    Session.get("promedFeedId")
+  resetToDate = (date)=>
     @posts.remove({})
     @recentAgents.remove({})
-    @ready.set(true)
-    @theEnd.set(false)
-    @currentPageNumber.set(0)
+    @loadingMorePosts.set(false)
+    @weeksWithNoPosts.set(0)
+    @startDate.set(date)
+    @endDate.set(date)
+    @pageEndDate.set(date)
     _.defer =>
       @loadMorePosts()
+  @autorun =>
+    Session.get("promedFeedId")
+    date = Router.current().getParams().query?.date
+    if date
+      resetToDate(moment(date))
+    else
+      resetToDate(moment())
 
 Template.recentAgents.helpers
   post: ->
-    Template.instance().posts.find({}, {sort: {order: 1}})
+    Template.instance().posts.find({}, {sort: {postDate: -1}})
+  ready: ->
+    not Template.instance().loadingMorePosts.get()
+  startDate: ->
+    Template.instance().startDate.get().format("MMM Do YYYY")
+  endDate: ->
+    Template.instance().endDate.get().format("MMM Do YYYY")
+  endDateBeforeToday: ->
+    Template.instance().endDate.get() < moment().set(
+      hour:0
+      minute:0
+      second:0
+    )
   theEnd: ->
-    Template.instance().theEnd.get()
+    Template.instance().weeksWithNoPosts.get() > 6
   isCollapsed: (postId) ->
     Template.instance().posts.findOne(postId).collapsed
   recentAgentsForPost: (postId, limit) ->

--- a/imports/ui/lists/recentAgents.jade
+++ b/imports/ui/lists/recentAgents.jade
@@ -1,4 +1,7 @@
 template(name="recentAgents")
+  if ready
+    if endDateBeforeToday
+      p.centered Posts before #{endDate}
   .list
     each post
       article.post

--- a/imports/ui/lists/recentAgents.jade
+++ b/imports/ui/lists/recentAgents.jade
@@ -18,9 +18,9 @@ template(name="recentAgents")
               a(href="/detail/{{plus word}}")= word
               .prior-mentions
                 if priorPost
-                  span {{since ../date priorPostDate}}
+                  span {{since postDate priorPostDate}}
                   span since
-                  a.promed-link.featured(href="#" uri=priorPost) prior mention
+                  a.featured(href="?date={{format priorPostDate 'YYYY-MM-DD'}}") prior mention
                 else
                   span.no-priors no prior mentions
         if collapsed


### PR DESCRIPTION
This also updates the recently mentioned diseases list to use dates for pagination, makes "since" times relative to to the mention's post date, and fixes a bug where non-utc post dates were causing "since" times to be off.