### PR TITLE
Restyle keyword-in-context to fix screenshot bug

### DIFF
--- a/imports/ui/helpers/misc.coffee
+++ b/imports/ui/helpers/misc.coffee
@@ -2,17 +2,10 @@ Template.registerHelper 'eq', (a, b) ->
   a == b
 
 Template.registerHelper 'kwic', ->
-  beforePhraseStart = Math.max(0, @t_start - 40 - @p_start)
-  afterPhraseEnd = @t_start + 40 - @p_start
-  beforePhrase = @phrase_text.slice(beforePhraseStart, @t_start - @p_start)
+  beforePhrase = @phrase_text.slice(0, @t_start - @p_start)
   keyPhrase    = @phrase_text.slice(@t_start - @p_start, @t_end - @p_start)
-  afterPhrase  = @phrase_text.slice(@t_end - @p_start, afterPhraseEnd)
-  if beforePhraseStart != 0
-    beforePhrase = "..." + beforePhrase
-  if afterPhraseEnd <= @phrase_text.length
-    afterPhrase += "..."
+  afterPhrase  = @phrase_text.slice(@t_end - @p_start)
   new Spacebars.SafeString """
-    <span>#{beforePhrase}</span>
-    #{keyPhrase}
-    <span>#{afterPhrase}</span>
+    <td>#{beforePhrase.replace(/\s$/, "&nbsp;").replace(/\n+/g, "<br>")}</td>
+    <td><span>#{keyPhrase}</span>#{afterPhrase}</td>
   """

--- a/imports/ui/lists/recentDescriptorMentions.jade
+++ b/imports/ui/lists/recentDescriptorMentions.jade
@@ -6,9 +6,8 @@ template(name="recentDescriptorMentions")
           a.promed-link.featured(href="#" uri=uri)=postSubject
         .time-link
           p {{age date}}
-      ul.keword-in-context-list.list--sub-group.list-unstyled
+      table.keyword-in-context-table
         each mentionsForSource _id
-          li
-            p.keword-in-context #{kwic}
+          tr=kwic
   else
     +loader classes='inline'

--- a/imports/ui/lists/recentMentions.jade
+++ b/imports/ui/lists/recentMentions.jade
@@ -13,10 +13,9 @@ template(name="recentMentions")
             p {{ageOrDate date}}
             span.seperator
             a.fa.fa-newspaper-o.promed-link(href="#" uri=uri)
-        ul.source-mentions.keword-in-context-list.list--sub-group.list-unstyled
+        table.keyword-in-context-table
           each mentionsForSource _id
-            li
-              p.keword-in-context #{kwic}
+            tr=kwic
     else
       if ready
         p.no-priors.centered.subtle No Recent Mentions

--- a/imports/ui/stylesheets/recent_mentions.import.styl
+++ b/imports/ui/stylesheets/recent_mentions.import.styl
@@ -1,4 +1,4 @@
-.keword-in-context-list
+.keyword-in-context-list
   li
     position relative
     display flex
@@ -24,32 +24,34 @@
       right 0
       background linear-gradient(to left, white, alpha(white, 0))
 
-.keword-in-context
-  position absolute
-  left 50%
-  top 50%
-  transform translate(-50%, -50%)
-  margin 0
-  font-weight 800
-  letter-spacing .01em
-  font-size .8em
-  +above(2)
-    font-size .9em
-  +above(3)
-    font-size 1em
-  span
-    position absolute
+.keyword-in-context-table
+  width 100%
+  tr
+    border-bottom 1px solid lighten($m-gray, 20%)
+  tr:last-child
+    border-bottom 0
+  td
+    line-height 1.6em
+    letter-spacing .01em
+    font-size .8em
+    padding 10px 0
+    +above(2)
+      font-size .9em
+    +above(3)
+      font-size 1em
+  td:nth-child(1)
+    width 45%
+    min-width 150px
+    text-align right
+    vertical-align top
+  td:nth-child(2)
+    span
+      font-weight 800
+    vertical-align bottom
     white-space nowrap
-    top 0
-    font-weight 400
-    letter-spacing 0
-  :nth-child(1)
-    left 0
-    transform translate(-102%, 0)
-  :nth-child(2)
-    right 0
-    transform translate(105%, 0)
-
+    overflow hidden
+    text-overflow ellipsis
+    max-width 250px
 .recent-mentions--header
   background $secondary
   padding 2.5em

--- a/imports/ui/stylesheets/recent_mentions.import.styl
+++ b/imports/ui/stylesheets/recent_mentions.import.styl
@@ -34,7 +34,7 @@
     line-height 1.6em
     letter-spacing .01em
     font-size .8em
-    padding 10px 0
+    padding 1.5em 0
     +above(2)
       font-size .9em
     +above(3)
@@ -42,16 +42,18 @@
   td:nth-child(1)
     width 45%
     min-width 150px
+    padding-left 1.5em
     text-align right
     vertical-align top
   td:nth-child(2)
-    span
-      font-weight 800
+    max-width 250px
+    padding-right 1.5em
     vertical-align bottom
     white-space nowrap
     overflow hidden
     text-overflow ellipsis
-    max-width 250px
+    span
+      font-weight 800
 .recent-mentions--header
   background $secondary
   padding 2.5em


### PR DESCRIPTION
Removing the css transforms prevents the issue of disappearing text. I redid the styles so that the full phrase beginning is included and can break over multiple lines.